### PR TITLE
Add health endpoints and probes

### DIFF
--- a/Readme.Md
+++ b/Readme.Md
@@ -67,3 +67,7 @@ kubectl apply -f k8s/service.yaml
 
 Ensure your environment variables are set using a `Secret` or `ConfigMap` when deploying to DigitalOcean Kubernetes.
 
+## 🔍 Health Endpoints
+
+The API exposes `/live` and `/ready` endpoints for Kubernetes liveness and readiness probes. These routes return `200 OK` when the service is running, and the readiness probe checks database connectivity.
+

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -21,8 +21,6 @@ func main() {
 		log.Println(".env file not found, relying on environment variables")
 	}
 
-
-
 	// // Build DSN and connect to DB
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s",
 		os.Getenv("DB_USER"),
@@ -59,6 +57,9 @@ func main() {
 
 	orderService := services.NewOrderService(orderRepo)
 
+	// Health handler uses db for readiness checks
+	healthHandler := handlers.NewHealthHandler(db)
+
 	// Initialize handlers
 	authHandler := handlers.NewAuthHandler(authSvc)
 	userHandler := handlers.NewUserHandler(userService)
@@ -70,7 +71,8 @@ func main() {
 	mux.HandleFunc("/login", authHandler.Login)
 	mux.HandleFunc("/users", userHandler.GetAllUsers)
 	mux.HandleFunc("/orders", orderHandler.CreateOrder)
-
+	mux.HandleFunc("/live", healthHandler.Live)
+	mux.HandleFunc("/ready", healthHandler.Ready)
 
 	protected := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("Secret data"))

--- a/internal/handler/health_handler.go
+++ b/internal/handler/health_handler.go
@@ -1,0 +1,28 @@
+package handlers
+
+import (
+	"database/sql"
+	"net/http"
+)
+
+type HealthHandler struct {
+	db *sql.DB
+}
+
+func NewHealthHandler(db *sql.DB) *HealthHandler {
+	return &HealthHandler{db: db}
+}
+
+func (h *HealthHandler) Live(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("ok"))
+}
+
+func (h *HealthHandler) Ready(w http.ResponseWriter, r *http.Request) {
+	if err := h.db.Ping(); err != nil {
+		http.Error(w, "database not ready", http.StatusServiceUnavailable)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("ok"))
+}

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -22,3 +22,15 @@ spec:
             name: ecommerce-secret
         ports:
         - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10


### PR DESCRIPTION
## Summary
- add `/live` and `/ready` endpoints for Kubernetes health checks
- configure deployment liveness and readiness probes
- document new health endpoints

## Testing
- `go test ./...` *(fails: downloading modules blocked)*
- `go vet ./...` *(fails: downloading modules blocked)*
