### PR TITLE
Add k8s HPA

### DIFF
--- a/Readme.Md
+++ b/Readme.Md
@@ -63,7 +63,9 @@ Apply the manifests in the `k8s/` directory:
 ```bash
 kubectl apply -f k8s/deployment.yaml
 kubectl apply -f k8s/service.yaml
+kubectl apply -f k8s/hpa.yaml
 ```
+The HPA automatically scales the Deployment replicas based on CPU load.
 
 Ensure your environment variables are set using a `Secret` or `ConfigMap` when deploying to DigitalOcean Kubernetes.
 

--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: ecommerce-api
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: ecommerce-api
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50
+


### PR DESCRIPTION
## Summary
- add HPA manifest to auto-scale deployment
- document applying the HPA when deploying to Kubernetes

## Testing
- `go build ./...` *(fails: proxy.golang.org access blocked)*
- `go test ./...` *(fails: proxy.golang.org access blocked)*


------
https://chatgpt.com/codex/tasks/task_e_686c01a34cc88321bea5e061b98d5d3a